### PR TITLE
Update main_avaliacao_projeto.py

### DIFF
--- a/developer/main_avaliacao_projeto.py
+++ b/developer/main_avaliacao_projeto.py
@@ -22,7 +22,7 @@ drive_service = auth.drive_service  # Obter o serviço de drive autenticado
 drive_manager = GoogleDriveManager(drive_service)  # Passar o serviço de drive para o construtor
 sheets_manager = GoogleSheetsManager(auth.sheets_client)
 
-
+# TODO: Com a centralização futura em um único main, considerar extrair esse bloco para uma função principal.
 try:
     # Transformação do raw para trusted
     processar_camada_raw(sheets_manager, drive_manager, relatorio)


### PR DESCRIPTION
Como o projeto será centralizado em um único main.py, pode ser interessante extrair esse bloco try/except para uma função genérica que receba os elementos variáveis (relatório, transformer, arquivo etc). Isso evitaria repetição entre os diferentes main, tornando o código mais limpo, modular e fácil de manter. Caso concordem com a ideia, posso contribuir com essa refatoração!